### PR TITLE
Fix for error message for rename-command when disabled in Redis-7.

### DIFF
--- a/spec/system/shared_examples/redis_instance.rb
+++ b/spec/system/shared_examples/redis_instance.rb
@@ -28,7 +28,7 @@ shared_examples_for 'a redis instance' do
           else
             expect {
               service_client.run(command)
-            }.to raise_error(/unknown command `#{command}`/)
+            }.to raise_error(/ERR unknown command '#{command}', with args beginning with:/)
           end
         end
       end


### PR DESCRIPTION
Administrative command like BGSAVE, MONITOR etc when disabled, throws different error message from previous redis version

CI -> https://runway-ci.eng.vmware.com/teams/tanzu-redis/pipelines/redis-3.5-tile-app-consolidation/jobs/run-system-tests-shared-redis/builds/17