### PR TITLE
REDVM-561: updates valkey bosh blob and uses valkey binaries in packaging script 

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -32,5 +32,5 @@ redis/redis-7.2.4.tar.gz:
   sha: sha256:0a62b9ae89b4be4e8d40c0035c83a72cb6776f4b62fe53553981a57f0f4ff73d
 valkey/valkey-7.2.5.tar.gz:
   size: 3420515
-  object_id: c8898c20-ef06-4d92-725c-08ac91394c39
+  object_id: 5d1c16d1-310d-4143-6b2b-0b7a31dabd5a
   sha: sha256:c7c7a758edabe7693b3692db58fe5328130036b06224df64ab1f0c12fe265a76

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -30,3 +30,7 @@ redis/redis-7.2.4.tar.gz:
   size: 3424072
   object_id: 5e7562f3-629b-4fa3-5ee2-7772949e775a
   sha: sha256:0a62b9ae89b4be4e8d40c0035c83a72cb6776f4b62fe53553981a57f0f4ff73d
+valkey/valkey-7.2.5.tar.gz:
+  size: 3420515
+  object_id: c8898c20-ef06-4d92-725c-08ac91394c39
+  sha: sha256:c7c7a758edabe7693b3692db58fe5328130036b06224df64ab1f0c12fe265a76

--- a/packages/redis-7.2/packaging
+++ b/packages/redis-7.2/packaging
@@ -1,18 +1,18 @@
 # abort script on any command that exits with a non zero value
 set -e
 
-target_dir="redis_source"
+target_dir="valkey_source"
 mkdir -p ${target_dir}
 
-tar xvf redis/redis-7.2.*.tar.gz -C ${target_dir} --strip-components 1
+tar xvf valkey/valkey-7.2.*.tar.gz -C ${target_dir} --strip-components 1
 
 cd ${target_dir}
 make
 
 BIN_TARGET=$BOSH_INSTALL_TARGET/bin
 mkdir $BIN_TARGET
-cp src/redis-server ${BIN_TARGET}
-cp src/redis-cli ${BIN_TARGET}
-cp src/redis-benchmark ${BIN_TARGET}
-cp src/redis-check-aof ${BIN_TARGET}
-cp src/redis-check-rdb ${BIN_TARGET}
+cp src/valkey-server ${BIN_TARGET}/redis-server
+cp src/valkey-cli ${BIN_TARGET}/redis-cli
+cp src/valkey-benchmark ${BIN_TARGET}/redis-benchmark
+cp src/valkey-check-aof ${BIN_TARGET}/redis-check-aof
+cp src/valkey-check-rdb ${BIN_TARGET}/redis-check-rdb

--- a/packages/redis-7.2/spec
+++ b/packages/redis-7.2/spec
@@ -2,7 +2,7 @@
 name: redis-7.2
 metadata:
   version:
-    redis: '7.2.4'
+    redis: '7.2.5'
 
 files:
-  - redis/redis-7.2.4.tar.gz
+  - valkey/valkey-7.2.5.tar.gz


### PR DESCRIPTION
# Changes:

adds the valkey source code as a bosh blob and uses the same in the packaging script to build binaries and rename it to the redis binaries.
