### PR TITLE
TNZ-24115: Updates the default version of the redis to 8.0

### DIFF
--- a/jobs/cf-redis-broker/spec
+++ b/jobs/cf-redis-broker/spec
@@ -33,7 +33,7 @@ provides:
 properties:
   redis.version:
     description: "Version of Redis to use"
-    default: "7.2"
+    default: "8.0"
 
   service-backup.source_folder:
     description: The directory in which we store service backups


### PR DESCRIPTION
during blob bump, the default version of the redis sepc version was missed to update.