### PR TITLE
TNZ-38100: updates the bucket-name due to gcp-migration

### DIFF
--- a/config/final.yml
+++ b/config/final.yml
@@ -4,4 +4,4 @@ min_cli_version: 1.5.0.pre.1113
 blobstore:
   provider: gcs
   options:
-    bucket_name: shared-redis-bosh-release-blobs
+    bucket_name: cf-redis-shared-redis-bosh-release-blobs


### PR DESCRIPTION
Bucket name change:
shared-redis-bosh-release-blobs -> cf-redis-shared-redis-bosh-release-blobs