### PR TITLE
TNZ-39948: Update BOSH blob valkey/valkey to 8.1.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -30,7 +30,7 @@ nginx/nginx-1.21.6.tar.gz:
   size: 1073364
   object_id: f4f0e190-4226-4642-7f8c-13cbd4bb8cf5
   sha: sha256:66dc7081488811e9f925719e34d1b4504c2801c81dee2920e5452a86b11405ae
-valkey/valkey-8.0.1.tar.gz:
-  size: 3625396
-  object_id: 383d862c-7e62-4fad-474a-375fc4ef1342
-  sha: sha256:1e1d6dfbed2f932a87afbc7402be050a73974a9b19a9116897e537a6638e5e1d
+valkey/valkey-8.1.1.tar.gz:
+  size: 3806719
+  object_id: 1961c63c-2525-4e66-6def-5677d95c8fda
+  sha: sha256:3355fbd5458d853ab201d2c046ffca9f078000587ccbe9a6c585110f146ad2c5

--- a/jobs/cf-redis-broker/spec
+++ b/jobs/cf-redis-broker/spec
@@ -19,7 +19,7 @@ packages:
 - cf-redis-broker
 - redis-common
 - cf-redis-nginx
-- redis-8.0
+- redis-8.1
 
 provides:
 - name: redis_broker
@@ -33,7 +33,7 @@ provides:
 properties:
   redis.version:
     description: "Version of Redis to use"
-    default: "8.0"
+    default: "8.1"
 
   service-backup.source_folder:
     description: The directory in which we store service backups

--- a/packages/redis-8.0/spec
+++ b/packages/redis-8.0/spec
@@ -1,8 +1,0 @@
----
-name: redis-8.0
-metadata:
-  version:
-    redis: '8.0.1'
-
-files:
-  - valkey/valkey-8.0.1.tar.gz

--- a/packages/redis-8.1/packaging
+++ b/packages/redis-8.1/packaging
@@ -4,7 +4,7 @@ set -e
 target_dir="valkey_source"
 mkdir -p ${target_dir}
 
-tar xvf valkey/valkey-8.0.*.tar.gz -C ${target_dir} --strip-components 1
+tar xvf valkey/valkey-8.1.*.tar.gz -C ${target_dir} --strip-components 1
 
 cd ${target_dir}
 make

--- a/packages/redis-8.1/spec
+++ b/packages/redis-8.1/spec
@@ -1,0 +1,8 @@
+---
+name: redis-8.1
+metadata:
+  version:
+    redis: '8.1.1'
+
+files:
+  - valkey/valkey-8.1.1.tar.gz


### PR DESCRIPTION
This PR contains below commits:
* fbca1a7 TNZ-39948: Update BOSH blob valkey/valkey to 8.1.1