### PR TITLE
TNZ-59145: fix ginkgo compile issue.

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -18,6 +18,10 @@ ginkgo/pprof-0.6e76a2b.tar.gz:
   size: 11714640
   object_id: 6e269e0c-fa74-4a24-648e-1a06436eb51f
   sha: sha256:e182294096242070e42ab06e848b4fbe3a5004d7d1383ab8d1579bd898ba7699
+ginkgo/semver-3.3.1.tar.gz:
+  size: 28210
+  object_id: b041c55f-88e4-4d61-6323-9d09c58c10cf
+  sha: sha256:495b165ada0aa6f8798d0ff2474c5982faf8e1b8418364149f490029f9f4cb35
 ginkgo/slim-sprig-2.20.1.tar.gz:
   size: 699090
   object_id: cd66cff6-cfd6-4844-4b10-83bc1859bd1b

--- a/packages/ginkgo/packaging
+++ b/packages/ginkgo/packaging
@@ -27,6 +27,9 @@ tar zxvf ginkgo/pprof-*.tar.gz --strip-components=1 -C "$GOPATH/src/github.com/g
 mkdir -p "$GOPATH/src/go.uber.org/automaxprocs"
 tar zxvf ginkgo/automaxprocs-*.tar.gz --strip-components=1 -C "$GOPATH/src/go.uber.org/automaxprocs"
 
+mkdir -p "$GOPATH/src/github.com/Masterminds/semver"
+tar zxvf ginkgo/semver-*.tar.gz --strip-components=1 -C "$GOPATH/src/github.com/Masterminds/semver"
+
 # remove pprof test binaries because they are failing CVE checks
 rm -rf $GOPATH/src/github.com/google/pprof/internal/report/testdata/
 

--- a/packages/ginkgo/spec
+++ b/packages/ginkgo/spec
@@ -2,12 +2,13 @@
 name: ginkgo
 metadata:
   version:
-    ginkgo: '2.20.0'
+    ginkgo: '2.25.3'
     tail-nxadm: '1.4.4'
     slim-sprig: '2.20.0'
     golang-sys: '1.17'
     golang-tools: '0.1.0'
     pprof: '0.0.1'
+    semver: '3.3.1'
 
 dependencies:
 - golang-1-linux
@@ -20,3 +21,4 @@ files:
 - ginkgo/golang-tools-0.1.0.tar.gz
 - ginkgo/pprof-0.6e76a2b.tar.gz
 - ginkgo/automaxprocs-1.6.0.tar.gz
+- ginkgo/semver-3.3.1.tar.gz


### PR DESCRIPTION
It requires an addition binary for semver. Adds the packages.